### PR TITLE
Add ArgoCD Applications for Helm and Kustomize deployments

### DIFF
--- a/argocd-applications/sample-app-helm-dev.yaml
+++ b/argocd-applications/sample-app-helm-dev.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sample-app-helm-dev
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/hiramekun/kubernetes-playground.git
+    targetRevision: HEAD
+    path: helm-config/apps/sample-app
+    helm:
+      valueFiles:
+        - ../../environments/dev/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: dev
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd-applications/sample-app-helm-prod.yaml
+++ b/argocd-applications/sample-app-helm-prod.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sample-app-helm-prod
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/hiramekun/kubernetes-playground.git
+    targetRevision: HEAD
+    path: helm-config/apps/sample-app
+    helm:
+      valueFiles:
+        - ../../environments/prod/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd-applications/sample-app-kustomize-dev.yaml
+++ b/argocd-applications/sample-app-kustomize-dev.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sample-app-kustomize-dev
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/hiramekun/kubernetes-playground.git
+    targetRevision: HEAD
+    path: kustomize-config/environments/dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: dev
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd-applications/sample-app-kustomize-prod.yaml
+++ b/argocd-applications/sample-app-kustomize-prod.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sample-app-kustomize-prod
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/hiramekun/kubernetes-playground.git
+    targetRevision: HEAD
+    path: kustomize-config/environments/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary
- Add ArgoCD Application manifests for GitOps deployments
- Support both Helm and Kustomize approaches for dev/prod environments
- Configure automated sync policies with prune and self-heal

## Applications Created
- **Helm-based**: `sample-app-helm-dev.yaml`, `sample-app-helm-prod.yaml`
- **Kustomize-based**: `sample-app-kustomize-dev.yaml`, `sample-app-kustomize-prod.yaml`

## Key Features
- Automated sync with prune and self-heal enabled
- Automatic namespace creation
- Environment-specific configurations
- Proper repository and path references

## Deployment Instructions
```bash
# Apply ArgoCD Applications to cluster
kubectl apply -f argocd-applications/

# Monitor deployments
argocd app list
argocd app sync sample-app-helm-dev
```

🤖 Generated with [Claude Code](https://claude.ai/code)